### PR TITLE
Enhance head metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,13 +6,27 @@
   <title>Atishay Jain</title>
   <meta name="description" content="Official site of Atishay Jain, founder of Hyperke Growth Partners and Eagle Info Services. Also known as Atishay, AX Jay, Atishay Jay, and AX Jain. Interviews, background, and contact.">
   <meta name="keywords" content="Atishay Jain, Atishay, AX Jay, Atishay Jay, AX Jain, Hyperke, Eagle Info Services">
-  <link rel="canonical" href="https://YOUR-DOMAIN.com/">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Atishay Jain">
   <meta property="og:description" content="Official site of Atishay Jain, founder of Hyperke Growth Partners and Eagle Info Services. Also known as Atishay, AX Jay, Atishay Jay, and AX Jain.">
   <meta property="og:image" content="https://YOUR-DOMAIN.com/assets/og-image.png">
   <meta property="og:site_name" content="Atishay Jain">
+  <meta property="og:url" content="https://YOUR-DOMAIN.com/">
+  <meta property="og:image:alt" content="Portrait of Atishay Jain">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:locale" content="en_US">
+  <meta name="twitter:title" content="Atishay Jain">
+  <meta name="twitter:description" content="Official site of Atishay Jain, founder of Hyperke Growth Partners and Eagle Info Services. Also known as Atishay, AX Jay, Atishay Jay, and AX Jain. Interviews, background, and contact.">
+  <meta name="twitter:image" content="https://YOUR-DOMAIN.com/assets/og-image.png">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="theme-color" content="#ffffff">
+  <meta name="author" content="Atishay Jain">
+  <link rel="canonical" href="https://YOUR-DOMAIN.com/">
+  <link rel="preconnect" href="https://hyperke.com">
+  <link rel="dns-prefetch" href="https://hyperke.com">
+  <link rel="preconnect" href="https://eagleinfoservices.com">
+  <link rel="dns-prefetch" href="https://eagleinfoservices.com">
   <link rel="icon" href="/assets/favicon.ico">
   <link rel="stylesheet" href="/assets/styles.css">
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- extend the index head with additional Open Graph and Twitter meta tags to improve social sharing
- add theme color, author, and canonical metadata before stylesheets for better SEO
- include preconnect and DNS prefetch hints for frequently linked external domains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1cd5f1e9c832e9b9e9ea5aa1cb3d6