### PR TITLE
Enhance JSON-LD metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@
     "alternateName": ["Atishay", "AX Jay", "Atishay Jay", "AX Jain", "Atishay Jain Hyperke"],
     "url": "https://YOUR-DOMAIN.com/",
     "jobTitle": "Founder",
+    "image": "https://YOUR-DOMAIN.com/assets/og-image.png",
+    "description": "Founder of Hyperke Growth Partners and Eagle Info Services leading performance-based outbound sales programs.",
     "worksFor": [{
       "@type": "Organization",
       "name": "Hyperke Growth Partners",
@@ -51,7 +53,9 @@
       "https://linkedin.com/in/atishay-hyperke",
       "https://www.youtube.com/@atishay-jain-hyperke",
       "https://hyperke.com/",
-      "https://eagleinfoservices.com/"
+      "https://eagleinfoservices.com/",
+      "https://twitter.com/atishayhyperke",
+      "https://www.instagram.com/atishayhyperke/"
     ]
   }
   </script>
@@ -119,6 +123,8 @@
         <ul class="socials">
           <li><a href="https://linkedin.com/in/atishay-hyperke" target="_blank" rel="noopener me" title="LinkedIn">LinkedIn</a></li>
           <li><a href="https://www.youtube.com/@atishay-jain-hyperke" target="_blank" rel="noopener" title="YouTube">YouTube</a></li>
+          <li><a href="https://twitter.com/atishayhyperke" target="_blank" rel="noopener" title="Twitter">Twitter</a></li>
+          <li><a href="https://www.instagram.com/atishayhyperke/" target="_blank" rel="noopener" title="Instagram">Instagram</a></li>
         </ul>
 
         <p><strong>Interviewed by SalesBlink:</strong><br>How we generate 500+ sales opportunities every<br>month without paid ads</p>


### PR DESCRIPTION
## Summary
- add image and description fields to the Person JSON-LD block in `index.html`
- extend the `sameAs` profile list with Twitter and Instagram entries to align with onsite CTAs
- surface new Twitter and Instagram CTAs in the Social Media list so the structured data URLs match onsite links

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1ce1f6480832ead7f5a9e3ed8732d