### PR TITLE
Add accessible header navigation and skip link

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -14,6 +14,56 @@ img{max-width:100%;height:auto}
 a{color:var(--accent);text-decoration:none}
 a:hover{text-decoration:underline}
 
+.skip-link{
+  position:absolute;
+  left:50%;
+  top:16px;
+  transform:translate(-50%,-200%);
+  background:var(--accent);
+  color:#fff;
+  padding:8px 14px;
+  border-radius:8px;
+  font-weight:600;
+  z-index:10;
+  transition:transform 0.2s ease;
+}
+.skip-link:focus{
+  transform:translate(-50%,16px);
+}
+
+.site-nav{
+  background:#fff;
+  border-bottom:1px solid #e5e5e5;
+}
+.site-nav .container{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:24px;
+  padding:16px 20px;
+}
+.site-nav .brand{
+  font-weight:700;
+  color:var(--text);
+  font-size:20px;
+}
+.site-nav ul{
+  display:flex;
+  align-items:center;
+  gap:20px;
+  list-style:none;
+  margin:0;
+  padding:0;
+}
+.site-nav li a{
+  color:var(--text);
+  font-weight:600;
+  font-size:16px;
+}
+.site-nav li a:hover{
+  color:var(--accent);
+}
+
 .container{width:100%;max-width:var(--container);margin:0 auto;padding:0 20px}
 .center{text-align:center}
 .narrow{max-width:800px}
@@ -62,6 +112,22 @@ ul{padding-left:20px;margin:0 0 16px}
 
 /* Mobile */
 @media (max-width:640px){
+  .site-nav .container{
+    flex-direction:column;
+    align-items:flex-start;
+    gap:12px;
+    padding:12px 20px;
+  }
+  .site-nav ul{
+    flex-wrap:wrap;
+    gap:12px 16px;
+  }
+  .site-nav li a{
+    font-size:14px;
+  }
+  .site-nav .brand{
+    font-size:18px;
+  }
   .hero{padding:72px 0 48px}
   h1{font-size:34px}
   h2{font-size:24px}

--- a/index.html
+++ b/index.html
@@ -57,26 +57,40 @@
   </script>
 </head>
 <body>
-  <header class="hero">
-    <div class="container center">
-      <div class="profile-wrap">
-        <img id="profilePhoto" class="profile-photo" src="/assets/profile-placeholder.png" alt="Portrait of Atishay Jain" loading="eager" decoding="async">
+  <header>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+    <nav class="site-nav" aria-label="Primary">
+      <div class="container">
+        <a class="brand" href="/">Atishay Jain</a>
+        <ul>
+          <li><a href="#about">About</a></li>
+          <li><a href="#background">Background</a></li>
+          <li><a href="#media">Media</a></li>
+          <li><a href="mailto:[email protected]">Contact</a></li>
+        </ul>
       </div>
-      <h1>Atishay Jain</h1>
-      <p class="tagline">TEDx Speaker, Author, Consultant | Founder - Hyperke Growth Partners</p>
-      <p class="cta-wrap">
-        <a class="btn" href="https://hyperke.com" target="_blank" rel="noopener me" title="Hyperke Website">
-          <span class="arrow" aria-hidden="true">➜</span>
-          Hyperke Website
-        </a>
-        <a class="btn btn-secondary" href="https://eagleinfoservices.com" target="_blank" rel="noopener" title="Eagle Info Services">
-          Eagle Info Services
-        </a>
-      </p>
+    </nav>
+    <div class="hero">
+      <div class="container center">
+        <div class="profile-wrap">
+          <img id="profilePhoto" class="profile-photo" src="/assets/profile-placeholder.png" alt="Portrait of Atishay Jain" loading="eager" decoding="async">
+        </div>
+        <h1>Atishay Jain</h1>
+        <p class="tagline">TEDx Speaker, Author, Consultant | Founder - Hyperke Growth Partners</p>
+        <div class="cta-wrap">
+          <a class="btn" href="https://hyperke.com" target="_blank" rel="noopener me" title="Hyperke Website">
+            <span class="arrow" aria-hidden="true">➜</span>
+            Hyperke Website
+          </a>
+          <a class="btn btn-secondary" href="https://eagleinfoservices.com" target="_blank" rel="noopener" title="Eagle Info Services">
+            Eagle Info Services
+          </a>
+        </div>
+      </div>
     </div>
   </header>
 
-  <main>
+  <main id="main-content">
     <section id="about">
       <div class="container narrow">
         <h2>About Atishay</h2>


### PR DESCRIPTION
## Summary
- wrap the hero area in a semantic header that introduces a skip-to-content link
- add a primary navigation bar with anchor links and restructure the CTA container markup
- style the skip link and navigation for desktop and mobile layouts

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d1ce222684832e80733f3e1962c634