### PR TITLE
Refine content sections into info cards

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -6,6 +6,12 @@
   --accent:#1a73e8;
   --container: 960px;
   --profile-size: 140px; /* adjust this to change hero photo size */
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --radius-md: 16px;
 }
 
 *{box-sizing:border-box}
@@ -53,6 +59,33 @@ h3{font-size:20px;margin:24px 0 8px}
 ul{padding-left:20px;margin:0 0 16px}
 .link-inline{font-weight:600}
 
+.grid{
+  display:grid;
+  gap:var(--space-lg);
+  grid-template-columns:1fr;
+}
+
+.info-card{
+  background:#f8fafc;
+  border:1px solid #e2e8f0;
+  border-radius:var(--radius-md);
+  padding:var(--space-lg);
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-sm);
+}
+
+.info-card h3{
+  margin:0;
+  font-size:20px;
+}
+
+.info-card p{margin:0}
+
+.info-card ul{margin:0;padding-left:20px}
+
+.info-card .socials{padding:0;margin:0}
+
 .divider{border:0;border-top:1px solid #e5e5e5;margin:8px 0}
 
 .socials{display:flex;flex-wrap:wrap;gap:16px;list-style:none;padding:0}
@@ -66,4 +99,12 @@ ul{padding-left:20px;margin:0 0 16px}
   h1{font-size:34px}
   h2{font-size:24px}
   .tagline{font-size:16px}
+}
+
+@media (min-width:640px){
+  .grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+}
+
+@media (min-width:960px){
+  .grid{grid-template-columns:repeat(3,minmax(0,1fr))}
 }

--- a/index.html
+++ b/index.html
@@ -89,20 +89,39 @@
     <section id="outside">
       <div class="container narrow">
         <h2>Outside of Work?</h2>
-        <ul>
-          <li>In his free time, you'd find Atishay loves at the nearest hike spot or at the beach catching waves</li>
-        </ul>
+        <div class="grid">
+          <article class="info-card">
+            <h3>Adventure &amp; Outdoors</h3>
+            <p>Atishay recharges by getting outside and embracing movement.</p>
+            <ul>
+              <li>Hitting nearby hiking trails</li>
+              <li>Chasing waves at the beach</li>
+            </ul>
+          </article>
+        </div>
       </div>
     </section>
 
     <section id="background">
       <div class="container narrow">
         <h2>Atishay's Professional Background</h2>
-        <ul>
-          <li>Bachelors' in Computer Science</li>
-          <li>AE at Amazon (AWS) - 2 years</li>
-        </ul>
-        <p><a class="link-inline" href="https://linkedin.com/in/atishay-hyperke" target="_blank" rel="noopener">Connect with Atishay on LinkedIn</a></p>
+        <div class="grid">
+          <article class="info-card">
+            <h3>Education</h3>
+            <p>Formal training anchored in technology and systems thinking.</p>
+            <ul>
+              <li>Bachelor's in Computer Science</li>
+            </ul>
+          </article>
+          <article class="info-card">
+            <h3>Experience</h3>
+            <p>Hands-on leadership across outbound growth and enterprise sales.</p>
+            <ul>
+              <li>Account Executive at Amazon (AWS) — 2 years</li>
+            </ul>
+            <p><a class="link-inline" href="https://linkedin.com/in/atishay-hyperke" target="_blank" rel="noopener">Connect with Atishay on LinkedIn</a></p>
+          </article>
+        </div>
       </div>
     </section>
 
@@ -113,23 +132,36 @@
         <h2>Interviews, Podcasts and Industry Media Coverage</h2>
         <p>Atishay loves connecting with industry experts to discuss the lates and the greatest in sales.</p>
         <p>For potential collaborations, feel free to reach out: <a href="mailto:[email protected]">[email protected]</a></p>
-
-        <h3>Social Media</h3>
-        <p>Let's connect on Socials</p>
-        <ul class="socials">
-          <li><a href="https://linkedin.com/in/atishay-hyperke" target="_blank" rel="noopener me" title="LinkedIn">LinkedIn</a></li>
-          <li><a href="https://www.youtube.com/@atishay-jain-hyperke" target="_blank" rel="noopener" title="YouTube">YouTube</a></li>
-        </ul>
-
-        <p><strong>Interviewed by SalesBlink:</strong><br>How we generate 500+ sales opportunities every<br>month without paid ads</p>
-
-        <p><strong>Hosted a Guest Session for the Semantic Mastery Hump Day Hangouts</strong></p>
-
-        <p><strong>Webinar with Smartlead.ai:</strong> Unlocking 69% Positive reply rates</p>
-
-        <p><strong>Industry Talks</strong> - My Most recent project where 7-figure marketing agency owners share Growth secrets to building multi-million dollar businesses</p>
-
-        <p><strong>Jeremy Jones' Ideas and Impact Podcast:</strong> Dispelling myths around Outbound Sales</p>
+        <div class="grid">
+          <article class="info-card">
+            <h3>Social Media</h3>
+            <p>Let's connect and keep the outbound conversation going.</p>
+            <ul class="socials">
+              <li><a href="https://linkedin.com/in/atishay-hyperke" target="_blank" rel="noopener me" title="LinkedIn">LinkedIn</a></li>
+              <li><a href="https://www.youtube.com/@atishay-jain-hyperke" target="_blank" rel="noopener" title="YouTube">YouTube</a></li>
+            </ul>
+          </article>
+          <article class="info-card">
+            <h3>SalesBlink Interview</h3>
+            <p>How Hyperke generates 500+ sales opportunities every month without paid ads.</p>
+          </article>
+          <article class="info-card">
+            <h3>Semantic Mastery Guest Session</h3>
+            <p>Shared outbound playbooks on the Hump Day Hangouts series.</p>
+          </article>
+          <article class="info-card">
+            <h3>Smartlead.ai Webinar</h3>
+            <p>Unlocked 69% positive reply rates through targeted outbound campaigns.</p>
+          </article>
+          <article class="info-card">
+            <h3>Industry Talks</h3>
+            <p>Latest project where 7-figure marketing agency owners share the systems behind multi-million dollar growth.</p>
+          </article>
+          <article class="info-card">
+            <h3>Ideas and Impact Podcast</h3>
+            <p>Joined Jeremy Jones to dispel myths around outbound sales.</p>
+          </article>
+        </div>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- refactor the Outside, Background, and Media sections into reusable info cards with structured lists and descriptions
- introduce card grid layouts, spacing tokens, and responsive breakpoints for improved presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1ce3276c8832eaeec4cdbbb3d4fe6